### PR TITLE
Next config fix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  target: 'serverless',
   i18n: {
     locales: ['en'],
     defaultLocale: 'en',


### PR DESCRIPTION
`next.config.js` was missing a required property (`target: 'serverless'`) when deploying on netlify.